### PR TITLE
Append `-std=c++11` flag to the module in SCsub

### DIFF
--- a/SCsub
+++ b/SCsub
@@ -1,4 +1,9 @@
 Import('env')
 
-env.add_source_files(env.modules_sources,"*.cpp")
-env.add_source_files(env.modules_sources,"lib/*.cpp")
+module_env = env.Clone()
+
+module_env.add_source_files(env.modules_sources,"*.cpp")
+module_env.add_source_files(env.modules_sources,"lib/*.cpp")
+
+# FastNoise uses a few C++11 features
+module_env.Append(CPPFLAGS=["-std=c++11"])

--- a/config.py
+++ b/config.py
@@ -5,5 +5,4 @@ def can_build(platform):
   
   
 def configure(env):
-    # FastNoise uses a few C++11 features
-    env.Append(SCONS_CXX_STANDARD="c++11")
+    pass


### PR DESCRIPTION
Scons doesn't seem to support the `SCONS_CXX_STANDARD` environ variable.

Fixes #1